### PR TITLE
chore(typescript version): use fixed ts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
   },
   "dependencies": {
     "@types/node": "^10.0.0",
-    "typescript": "^3.7.5"
+    "typescript": "3.7.5"
   }
 }


### PR DESCRIPTION
The new typescript version caused some tests failures because of a change in the compiler error messages (we are using snapshots testing).
i can fix the snapshots messages but it won't ensure that those kind of failures won't come back in the future.. WDYT?