### PR TITLE
[Types Platformization] Support not serving base libs (ES2020 & WebWorker) so we can use `monaco-typescript` bundles base libs.

### DIFF
--- a/configs/no-lib/tsconfig.backend.json
+++ b/configs/no-lib/tsconfig.backend.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "typeRoots": ["../../"],
+    "types": ["types/backend", "node_modules/@types/node"]
+  }
+}

--- a/configs/no-lib/tsconfig.base.json
+++ b/configs/no-lib/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "noLib": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "checkJs": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2020"
+  }
+}

--- a/configs/no-lib/tsconfig.pages.json
+++ b/configs/no-lib/tsconfig.pages.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "typeRoots": ["../../"],
+    "types": ["types/pages"]
+  }
+}

--- a/configs/no-lib/tsconfig.public.json
+++ b/configs/no-lib/tsconfig.public.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "typeRoots": ["../../"],
+    "types": ["types/public"]
+  }
+}

--- a/configs/no-lib/tsconfig.target_es.json
+++ b/configs/no-lib/tsconfig.target_es.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noLib": false,
+    "lib": ["ES2020"]
+  }
+}

--- a/configs/no-lib/tsconfig.webworker.json
+++ b/configs/no-lib/tsconfig.webworker.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noLib": false,
+    "lib": ["WebWorker"]
+  }
+}

--- a/scripts/generate-full-corvid-types.js
+++ b/scripts/generate-full-corvid-types.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 const fs = require("fs-extra");
 const path = require("path");
-const without_ = require("lodash/without");
 
 const createTsProgram = require("./createTypescriptProgram");
-const { TS_CONFIG_PATHS, TS_CONFIG_BASE_PATH } = require("../src/constants");
+const { NO_LIB_TS_CONFIG_PATHS } = require("../src/constants");
 
 const projectRoot = path.join(__dirname, "../");
 const FULL_CORVID_DECLARATION_PATH = path.join(
@@ -23,18 +22,10 @@ const getDeclarationFilesFromTsConfig = configPath => {
 };
 
 async function generateFullCorvidDeclarations() {
-  const corvidLib = {
-    BASE: getDeclarationFilesFromTsConfig(
-      path.join(projectRoot, TS_CONFIG_BASE_PATH)
-    )
-  };
-
-  Object.keys(TS_CONFIG_PATHS).forEach(context => {
-    corvidLib[context] = without_(
-      getDeclarationFilesFromTsConfig(
-        path.join(projectRoot, TS_CONFIG_PATHS[context])
-      ),
-      ...corvidLib.BASE
+  const corvidLib = {};
+  Object.keys(NO_LIB_TS_CONFIG_PATHS).forEach(context => {
+    corvidLib[context] = getDeclarationFilesFromTsConfig(
+      path.join(projectRoot, NO_LIB_TS_CONFIG_PATHS[context])
     );
   });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,23 @@
+const TARGET_ES_LIB = "ES2020";
+const WEB_WORKER_LIB = "WebWorker";
+
 module.exports = {
   TS_CONFIG_PATHS: {
     BACKEND: "configs/tsconfig.backend.json",
     PUBLIC: "configs/tsconfig.public.json",
     PAGES: "configs/tsconfig.pages.json"
+  },
+  NO_LIB_TS_CONFIG_PATHS: {
+    BACKEND: "configs/no-lib/tsconfig.backend.json",
+    PUBLIC: "configs/no-lib/tsconfig.public.json",
+    PAGES: "configs/no-lib/tsconfig.pages.json",
+    TARGET_ES: "configs/no-lib/tsconfig.target_es.json",
+    WEB_WORKER: "configs/no-lib/tsconfig.webworker.json"
+  },
+  BASE_LIBS: {
+    BACKEND: [TARGET_ES_LIB],
+    PUBLIC: [TARGET_ES_LIB, WEB_WORKER_LIB],
+    PAGES: [TARGET_ES_LIB, WEB_WORKER_LIB]
   },
   TS_CONFIG_BASE_PATH: "configs/tsconfig.base.json"
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 import fullCorvidTypes from "../dist/fullCorvidTypes.json";
 import wixModulesNames from "../dist/wixModules.json";
 import eventHandlersService from "./dynamicTypes/eventHandlersService";
-import { TS_CONFIG_PATHS } from "./constants";
+import { TS_CONFIG_PATHS, BASE_LIBS } from "./constants";
 import dynamicTypings from "./dynamicTypes";
 
 export * from "./dynamicTypes/eventHandlersService";
@@ -15,26 +15,51 @@ module.exports = {
     backend: `corvid-types/${TS_CONFIG_PATHS.BACKEND}`,
     public: `corvid-types/${TS_CONFIG_PATHS.PUBLIC}`
   },
+  baseLibs: {
+    page: BASE_LIBS.PAGES,
+    backend: BASE_LIBS.BACKEND,
+    public: BASE_LIBS.PUBLIC
+  },
   declarations: {
-    page: ({ dependencies, elementsMap, widgets }: any = {}) => {
+    page: ({
+      includeBaseLibs = true,
+      dependencies,
+      elementsMap,
+      widgets
+    }: any = {}) => {
+      const baseLibs = includeBaseLibs
+        ? [
+            ...(fullCorvidTypes as any).TARGET_ES,
+            ...(fullCorvidTypes as any).WEB_WORKER
+          ]
+        : [];
       return [
-        ...(fullCorvidTypes as any).BASE,
+        ...baseLibs,
         ...(fullCorvidTypes as any).PAGES,
         ...dynamicTypings.elementsMap.getFiles(elementsMap),
         ...dynamicTypings.widget.getFiles(widgets),
         ...dynamicTypings.packages.getFiles(dependencies)
       ];
     },
-    backend: ({ dependencies }: any) => {
+    backend: ({ includeBaseLibs = true, dependencies }: any) => {
+      const baseLibs = includeBaseLibs
+        ? [...(fullCorvidTypes as any).TARGET_ES]
+        : [];
       return [
-        ...(fullCorvidTypes as any).BASE,
+        ...baseLibs,
         ...(fullCorvidTypes as any).BACKEND,
         ...dynamicTypings.packages.getFiles(dependencies)
       ];
     },
-    public: ({ dependencies }: any) => {
+    public: ({ includeBaseLibs = true, dependencies }: any) => {
+      const baseLibs = includeBaseLibs
+        ? [
+            ...(fullCorvidTypes as any).TARGET_ES,
+            ...(fullCorvidTypes as any).WEB_WORKER
+          ]
+        : [];
       return [
-        ...(fullCorvidTypes as any).BASE,
+        ...baseLibs,
         ...(fullCorvidTypes as any).PUBLIC,
         ...dynamicTypings.packages.getFiles(dependencies)
       ];


### PR DESCRIPTION
* `monaco-typescript` already bundles the base libs we need: ES2020 and WebWorker
* So we can omit these base libs from corvid-types
* `code-code` will have an experiment to either ask for those base libs from `corvid-types` or not.
* Once we fully open the experiment - I'll remove the base libs from `corvid-types` completely