### PR TITLE
[Types Platformization] `fullCorvidTypes.json` to only include the contents of each lib once

### DIFF
--- a/scripts/generate-full-corvid-types.js
+++ b/scripts/generate-full-corvid-types.js
@@ -29,17 +29,30 @@ async function generateFullCorvidDeclarations() {
     );
   });
 
-  Object.keys(corvidLib).forEach(context => {
-    corvidLib[context] = corvidLib[context].map(path => ({
-      path: path.split("corvid-types").pop(),
-      content: fs.readFileSync(path, "utf8")
-    }));
-  });
+  const uniqueLibs = [
+    ...new Set(
+      Object.values(corvidLib).reduce((soFar, libs) => {
+        return [...soFar, ...libs];
+      }, [])
+    )
+  ];
+
+  const libs = uniqueLibs.map(path => ({
+    path: path.split("corvid-types").pop(),
+    content: fs.readFileSync(path, "utf8")
+  }));
 
   fs.ensureFileSync(FULL_CORVID_DECLARATION_PATH);
   fs.writeFileSync(
     FULL_CORVID_DECLARATION_PATH,
-    JSON.stringify(corvidLib, null, 2)
+    JSON.stringify(
+      {
+        libs,
+        contexts: corvidLib
+      },
+      null,
+      2
+    )
   );
 }
 

--- a/src/dynamicTypes/fullCorvidTypes.ts
+++ b/src/dynamicTypes/fullCorvidTypes.ts
@@ -1,0 +1,29 @@
+import fullCorvidTypesJSON from "../../dist/fullCorvidTypes.json";
+
+export enum LibCollections {
+  BACKEND = "BACKEND",
+  PUBLIC = "PUBLIC",
+  PAGES = "PAGES",
+  TARGET_ES = "TARGET_ES",
+  WEB_WORKER = "WEB_WORKER"
+}
+
+type Lib = {
+  path: string;
+  content: string;
+};
+
+type FullCorvidTypes = {
+  contexts: Record<LibCollections, string[]>;
+  libs: Array<Lib>;
+};
+
+export const fullCorvidTypes = fullCorvidTypesJSON as FullCorvidTypes;
+
+export const getCollectionLibs = (key: LibCollections): Lib[] => {
+  return fullCorvidTypes.contexts[key]
+    .map(libPath => {
+      return fullCorvidTypes.libs.find(lib => libPath.includes(lib.path));
+    })
+    .filter((lib): lib is Lib => lib !== undefined);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-import fullCorvidTypes from "../dist/fullCorvidTypes.json";
 import wixModulesNames from "../dist/wixModules.json";
 import eventHandlersService from "./dynamicTypes/eventHandlersService";
+import {
+  getCollectionLibs,
+  LibCollections
+} from "./dynamicTypes/fullCorvidTypes";
 import { TS_CONFIG_PATHS, BASE_LIBS } from "./constants";
 import dynamicTypings from "./dynamicTypes";
 
@@ -29,13 +32,13 @@ module.exports = {
     }: any = {}) => {
       const baseLibs = includeBaseLibs
         ? [
-            ...(fullCorvidTypes as any).TARGET_ES,
-            ...(fullCorvidTypes as any).WEB_WORKER
+            ...getCollectionLibs(LibCollections.TARGET_ES),
+            ...getCollectionLibs(LibCollections.WEB_WORKER)
           ]
         : [];
       return [
         ...baseLibs,
-        ...(fullCorvidTypes as any).PAGES,
+        ...getCollectionLibs(LibCollections.PAGES),
         ...dynamicTypings.elementsMap.getFiles(elementsMap),
         ...dynamicTypings.widget.getFiles(widgets),
         ...dynamicTypings.packages.getFiles(dependencies)
@@ -43,24 +46,24 @@ module.exports = {
     },
     backend: ({ includeBaseLibs = true, dependencies }: any) => {
       const baseLibs = includeBaseLibs
-        ? [...(fullCorvidTypes as any).TARGET_ES]
+        ? getCollectionLibs(LibCollections.TARGET_ES)
         : [];
       return [
         ...baseLibs,
-        ...(fullCorvidTypes as any).BACKEND,
+        ...getCollectionLibs(LibCollections.BACKEND),
         ...dynamicTypings.packages.getFiles(dependencies)
       ];
     },
     public: ({ includeBaseLibs = true, dependencies }: any) => {
       const baseLibs = includeBaseLibs
         ? [
-            ...(fullCorvidTypes as any).TARGET_ES,
-            ...(fullCorvidTypes as any).WEB_WORKER
+            ...getCollectionLibs(LibCollections.TARGET_ES),
+            ...getCollectionLibs(LibCollections.WEB_WORKER)
           ]
         : [];
       return [
         ...baseLibs,
-        ...(fullCorvidTypes as any).PUBLIC,
+        ...getCollectionLibs(LibCollections.PUBLIC),
         ...dynamicTypings.packages.getFiles(dependencies)
       ];
     }


### PR DESCRIPTION
## Summary

Before => `fullCorvidTypes.json` included multiple copies of a libs content if it was used by multiple contexts.

![image](https://user-images.githubusercontent.com/6196971/146396351-375dc3b2-5799-450f-a6a3-ed53b6f4baf1.png)

Now => `fullCorvidTypes.json` only includes each lib's content once.
![image](https://user-images.githubusercontent.com/6196971/146396320-210ecfb2-3692-4c10-b4de-b7c6565e4740.png)

## Details

`fullCorvidTypes.json` has a new structure:
```typescript
type Lib = {
  path: string;
  content: string;
};

type FullCorvidTypes = {
  contexts: Record<LibCollections, string[]>;
  libs: Array<Lib>;
};
```

