### PR TITLE
add eslint-disable in wix-auth.d.ts fixture

### DIFF
--- a/test/scripts/__snapshots__/ast-patches.spec.js.snap
+++ b/test/scripts/__snapshots__/ast-patches.spec.js.snap
@@ -1,12 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Ast patches ChangeWixAuthElevateFunctionType Should apply patch 1`] = `
-"declare module 'wix-auth' {
+"// It compares the result to a snapshot, if lint fixes this file snapshot will fail
+/* eslint-disable */
+declare module 'wix-auth' {
     /**
      * Returns an instance of the specified function for which the site visitor's permissions have been elevated to the highest level required.
      * 	[Read more](https://www.wix.com/corvid/reference/wix-auth.html#elevate)
      */
     function elevate<T extends (...arg: any) => any>(func: T): (...param: Parameters<T>) => ReturnType<T>;
 }
+/* eslint-enable */
 "
 `;

--- a/test/scripts/fixtures/wix-auth/wix-auth.d.ts
+++ b/test/scripts/fixtures/wix-auth/wix-auth.d.ts
@@ -1,3 +1,5 @@
+// It compares the result to a snapshot, if lint fixes this file snapshot will fail
+/* eslint-disable */
 declare module 'wix-auth' {
   /**
    * Returns an instance of the specified function for which the site visitor's permissions have been elevated to the highest level required.
@@ -5,3 +7,4 @@ declare module 'wix-auth' {
    */
   function elevate(functionName: Function): Function;
 }
+/* eslint-enable */


### PR DESCRIPTION
Add eslint-disable in wix-auth.d.ts fixture so it won't brake the snapshot if lint tries to fix it (seems to have happened [here](https://wix.slack.com/archives/C01M2PN7K8R/p1640590907080000))
