### PR TITLE
On CI always do production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const env = process.env.NODE_ENV || "development";
+const env = process.env.CI ? "production" : (process.env.NODE_ENV || "development");
 const DIST = path.join(__dirname, "./dist");
 
 const baseConfig = libraryTarget => ({


### PR DESCRIPTION
This:
https://unpkg.com/corvid-types@0.4.7/dist/fullCorvidTypesJSON.esm.chunk.js
ends up as a `development` build, 300Kb larger than it could be if built in `production` mode.

```
➜  corvid-types git:(master) ✗ du -h dist/fullCorvidTypesJSON.esm.chunk.js
3.8M	dist/fullCorvidTypesJSON.esm.chunk.js

...
➜  corvid-types git:(master) ✗ du -h dist/fullCorvidTypesJSON.esm.chunk.js
3.5M	dist/fullCorvidTypesJSON.esm.chunk.js
```

In this PR I suggest checking the `CI` env variable to force `production` build, a better approach would be to use `is-ci` package, but not sure how are you with adding additional dependency ¯\_(ツ)_/¯

Travis CI sets `CI=true` [by default](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)


