### PR TITLE
fix event handlers param bug

### DIFF
--- a/scripts/generate-components-handlers/event-handlers-parser.ts
+++ b/scripts/generate-components-handlers/event-handlers-parser.ts
@@ -51,7 +51,9 @@ const getEventHandlersParser = (
     return [
       {
         name: eventHandlerParameter.name.getText(),
-        type: eventHandlerParameter.type?.getText()
+        type: `${
+          Constants.$W_MODULE_NAME
+        }.${eventHandlerParameter.type?.getText()}`
       }
     ];
   };

--- a/test/scripts/generate-event-handlers-json.spec.ts
+++ b/test/scripts/generate-event-handlers-json.spec.ts
@@ -52,7 +52,7 @@ describe("generate-events", () => {
       handlerArgs: [
         {
           name: "event",
-          type: "Event"
+          type: "$w.Event"
         }
       ]
     });
@@ -66,7 +66,7 @@ describe("generate-events", () => {
       handlerArgs: [
         {
           name: "event",
-          type: "MouseEvent"
+          type: "$w.MouseEvent"
         }
       ]
     });


### PR DESCRIPTION
since [this commit](https://github.com/wix-incubator/corvid-types/commit/72b5ae7d743f5f0c7ed47f5bbd5e01867f73a8fa) we have a bug in the elements panel (aka properties panel).
when a user adds new event the jsdoc annotation that is been generated has an error marker.
![Screen Shot 2022-03-07 at 12 17 25](https://user-images.githubusercontent.com/222435/157012304-f52fc4e7-4ba1-474f-b6c8-bf4ed4108b18.png)
this PR fix the issue by adding $w to the event handlers param which removes the marker.
![Screen Shot 2022-03-07 at 12 17 45](https://user-images.githubusercontent.com/222435/157012455-2f4573cb-56eb-4512-95d8-55faadc79a71.png)

